### PR TITLE
Avoid race condition when parsing a malformed XLSX

### DIFF
--- a/src/xlsx/utils.nim
+++ b/src/xlsx/utils.nim
@@ -841,6 +841,10 @@ proc parseSheet(fileName: string, styles: Styles, date1904: bool,
       # discard />
       x.next()
       break
+    elif x.kind == xmlEof:
+      break
+    else:
+      discard
 
   var position: int
   # parse data


### PR DESCRIPTION
If the file does not include `dimension` then we introduce a race in this while-loop. The PR ensures, that when the end of file is reached we'll break.