### PR TITLE
fixing `parseRowData()` to break loop after end of row and `parseSheet()` to end parsing after end of sheetData

### DIFF
--- a/src/xlsx/utils.nim
+++ b/src/xlsx/utils.nim
@@ -794,7 +794,6 @@ proc parseRowMetaData(x: var XmlParser, s: SheetInfo, styles: Styles): (int, She
   result = (pos, value)
 
 proc parseRowData(x: var XmlParser, s: var Sheet, styles: Styles, position: var int) {.inline.} =
-
   while true:
     x.next()
     case x.kind
@@ -803,12 +802,14 @@ proc parseRowData(x: var XmlParser, s: var Sheet, styles: Styles, position: var 
         let (pos, value) = parseRowMetaData(x, s.info, styles)
         position = pos
         s.data[pos] = value
+    of xmlElementEnd:
+      if x.elementName =?= "row":
+        # no more cells to parse on the line
+        break
     of xmlEof:
       break
     else:
       discard
-  # ignore />
-  x.next()
 
 proc parseSheet(fileName: string, styles: Styles, date1904: bool,
     trailingRows = false): Sheet {.inline.} =
@@ -864,6 +865,10 @@ proc parseSheet(fileName: string, styles: Styles, date1904: bool,
             break
           else:
             discard
+    of xmlElementEnd:
+      if x.elementName =?= "sheetData":
+        # no more data to parse
+        break
     of xmlEof:
       break
     else:

--- a/src/xlsx/utils.nim
+++ b/src/xlsx/utils.nim
@@ -849,30 +849,31 @@ proc parseSheet(fileName: string, styles: Styles, date1904: bool,
 
   var position: int
   # parse data
-  while true:
-    x.next()
-    case x.kind
-    of xmlElementStart:
-      if x.elementName =?= "sheetData":
-        # ignore <sheetData>
-        while true:
-          x.next()
-          case x.kind
-          of xmlElementOpen:
-            if x.elementName =?= "row":
-              x.parseRowData(result, styles, position)
-          of xmlEof:
-            break
-          else:
-            discard
-    of xmlElementEnd:
-      if x.elementName =?= "sheetData":
-        # no more data to parse
+  block parseSheetData:
+    while true:
+      x.next()
+      case x.kind
+      of xmlElementStart:
+        if x.elementName =?= "sheetData":
+          # ignore <sheetData>
+          while true:
+            x.next()
+            case x.kind
+            of xmlElementOpen:
+              if x.elementName =?= "row":
+                x.parseRowData(result, styles, position)
+            of xmlElementEnd:
+              if x.elementName =?= "sheetData":
+                # no more data to parse
+                break parseSheetData
+            of xmlEof:
+              break
+            else:
+              discard
+      of xmlEof:
         break
-    of xmlEof:
-      break
-    else:
-      discard
+      else:
+        discard
 
   if trailingRows:
     result.data.setLen(position + 1)


### PR DESCRIPTION
`parseRowData()` before this PR, the inner loop would not return to the scope of `parseSheet()` until `xmlEof`. In my view this was a mistake and will also facilitate what I intend to implement.

`parseSheet()` now ends parsing after end of sheetData